### PR TITLE
Fix Reader leak by removing useless copy

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -80,7 +80,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
               reuseContainers,
               caseSensitive,
               null);
-      this.conf = readConf.copy();
+      this.conf = readConf;
       return readConf;
     }
     return conf;


### PR DESCRIPTION
The ReadConf copy constructor will nullify the reader of source, thus leaving the reader of origin unclosed